### PR TITLE
Add Phone Number Validation for Swedish Format

### DIFF
--- a/javascript/bookroom2.js
+++ b/javascript/bookroom2.js
@@ -17,6 +17,8 @@ export function generateBookroom2() {
   const participants_select = document.createElement("select");
   const participants_number = document.createElement("option");
   const booking_button = document.createElement("button");
+  const book_phone_label = document.createElement("label");
+  const book_phone_input = document.createElement("input");
 
   // Sets classname and attributes on elements //
   overlay.className = "overlay";
@@ -47,9 +49,15 @@ export function generateBookroom2() {
 
   booking_button.className = "booking_button";
 
+  book_phone_label.className ="phone_number";
+  book_phone_label.setAttribute("for","phone-number");
+  book_phone_input.type ="number";
+  book_phone_input.id = "phone-number"
+
   // Text on elements //
   modal__title2.textContent = "";
   book_name_label.textContent = "Name";
+  book_phone_label.textContent ="Phone number";
   book_email_label.textContent = "Email";
   book_time_label.textContent = "What time?";
   participants_label.textContent = "How many participants?";
@@ -63,6 +71,8 @@ export function generateBookroom2() {
   book_form.appendChild(modal__title2);
   book_form.appendChild(book_name_label);
   book_form.appendChild(book_name_input);
+  book_form.appendChild(book_phone_label);
+  book_form.appendChild(book_phone_input);
   book_form.appendChild(book_email_label);
   book_form.appendChild(book_email_input);
   book_form.appendChild(book_time_label);
@@ -72,6 +82,7 @@ export function generateBookroom2() {
   book_form.appendChild(participants_select);
   participants_select.appendChild(participants_number);
   book_form.appendChild(booking_button);
+ 
 }
 generateBookroom2();
 
@@ -110,6 +121,7 @@ book_form.addEventListener("submit", (event) => {
 
   const userRoomId = parseInt(roomId, 10);
   const userInputName = document.getElementById("name-text").value;
+  const userInputPhone = document.getElementById("phone-number").value;
   const userInputEmail = document.getElementById("email-text").value;
   const date = new Date().toISOString();
   const userInputTime = document.getElementById("time_options").value;
@@ -120,6 +132,7 @@ book_form.addEventListener("submit", (event) => {
   const userInput = {
     challenge: userRoomId,
     name: userInputName,
+    phone: userInputPhone,
     email: userInputEmail,
     date: date,
     time: userInputTime,
@@ -144,6 +157,13 @@ book_form.addEventListener("submit", (event) => {
     .then(() => {
       document.querySelector(".modal3").removeAttribute("id");
     });
+
+    const phoneNumberCheck = document.querySelector("#phone-number")?.value;
+    if(phoneNumberCheck) {
+      console.log(`Phone number provided: ${phoneNumberCheck}`);
+    } else {
+      console.log("Phone number not provided, not an requirement");
+    }
 });
 
 export function availableTimeNow(newTime) {

--- a/javascript/bookroom2.js
+++ b/javascript/bookroom2.js
@@ -57,7 +57,7 @@ export function generateBookroom2() {
   // Text on elements //
   modal__title2.textContent = "";
   book_name_label.textContent = "Name";
-  book_phone_label.textContent ="Phone number";
+  book_phone_label.textContent ="Phone number(optional)";
   book_email_label.textContent = "Email";
   book_time_label.textContent = "What time?";
   participants_label.textContent = "How many participants?";

--- a/javascript/bookroom2.js
+++ b/javascript/bookroom2.js
@@ -19,6 +19,7 @@ export function generateBookroom2() {
   const booking_button = document.createElement("button");
   const book_phone_label = document.createElement("label");
   const book_phone_input = document.createElement("input");
+  
 
   // Sets classname and attributes on elements //
   overlay.className = "overlay";
@@ -51,13 +52,15 @@ export function generateBookroom2() {
 
   book_phone_label.className ="phone_number";
   book_phone_label.setAttribute("for","phone-number");
-  book_phone_input.type ="number";
+  book_phone_input.type ="tel";
   book_phone_input.id = "phone-number"
+  book_phone_input.value = "(+46)";
 
   // Text on elements //
   modal__title2.textContent = "";
   book_name_label.textContent = "Name";
   book_phone_label.textContent ="Phone number(optional)";
+  
   book_email_label.textContent = "Email";
   book_time_label.textContent = "What time?";
   participants_label.textContent = "How many participants?";
@@ -90,6 +93,7 @@ generateBookroom2();
 const book_form = document.querySelector(".book_form");
 const modal__title2 = document.querySelector(".modal__title2");
 
+  
 // Declare roomId value that imports the ID from bookroom modal (step 1)
 let roomId;
 
@@ -155,17 +159,45 @@ book_form.addEventListener("submit", (event) => {
       return response.json();
     })
     .then(() => {
-      document.querySelector(".modal3").removeAttribute("id");
-    });
+    document.querySelector(".modal3").removeAttribute("id");
+      let phoneNumberCheck = document.querySelector("#phone-number")?.value;
 
-    const phoneNumberCheck = document.querySelector("#phone-number")?.value;
-    if(phoneNumberCheck) {
+      let phoneInputAreaCode = document.querySelector("#phone-number");
+      phoneInputAreaCode.addEventListener("focus", () => {
+        if (!phoneInputAreaCode.value.startsWith("(+46)")) {
+          phoneInputAreaCode.value = "(+46)";
+        }
+      });
+
+      
+
+    if(phoneNumberCheck && phoneNumberCheck.length === 10 && !isNaN(phoneNumberCheck)) {
       console.log(`Phone number provided: ${phoneNumberCheck}`);
-    } else {
-      console.log("Phone number not provided, not an requirement");
-    }
-});
+      document.querySelector(".modal3").removeAttribute("id");
 
+      
+    } 
+    else if (isNaN(phoneNumberCheck) && phoneNumberCheck.length === 15) {
+      phoneInputAreaCode = phoneNumberCheck.substring(5, 15);
+      console.log(`Phone number provided: ${phoneInputAreaCode}`);
+      document.querySelector(".modal3").removeAttribute("id");
+    }
+    else if (phoneNumberCheck.length !== 0 && phoneNumberCheck.length !== 15 && phoneNumberCheck.length !== 10) {
+      console.log("Wrong phone format, try again");
+      if (document.querySelector(".modal3")) {
+        document.querySelector(".modal3").setAttribute("id", "hidden"); // Hide modal3 if invalid phone number
+        
+      }
+    }
+    else {
+      document.querySelector("#phone-number").value = "";
+      console.log("Phone number not provided, not an requirement");
+      document.querySelector(".modal3").removeAttribute("id");
+    }
+      
+    });
+  
+});
 export function availableTimeNow(newTime) {
   // This resets the time select options in every booking //
   const timeSelect = document.querySelector("#time_options");

--- a/src/sections/challenges.scss
+++ b/src/sections/challenges.scss
@@ -235,7 +235,13 @@ h2{
     border-style: solid;
     height: 30px;
     width: 250px;
+
 }
+.booking_button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
 
 .filter {
     /* Made the filter window only visible in desktop mode, for now */

--- a/src/sections/challenges.scss
+++ b/src/sections/challenges.scss
@@ -218,7 +218,24 @@ h2{
         border: none;
         
     }
-
+.phone_number {
+    font-size: 12px;
+    font-weight: 600;
+    margin: 10px 0 -5px 30px;
+    display: flex;
+    color:rgb(26, 26, 26);
+    opacity: 75%;
+}
+#phone-number{
+    position: relative;
+    margin: 0px 0 10px 30px;
+    bottom:2px;
+    border-radius: 3px;
+    border-color: rgb(201, 200, 200);
+    border-style: solid;
+    height: 30px;
+    width: 250px;
+}
 
 .filter {
     /* Made the filter window only visible in desktop mode, for now */

--- a/style.css
+++ b/style.css
@@ -803,7 +803,7 @@
   font-weight: 600;
   top: 22%;
   right: 31%;
-  z-index: 3;
+  z-index: 4;
 }
 
 ::-webkit-datetime-edit-month-field {
@@ -925,6 +925,26 @@ h2 {
   bottom: 22%;
   right: 31%;
   border: none;
+}
+
+.phone_number {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 10px 0 -5px 30px;
+  display: flex;
+  color: rgb(26, 26, 26);
+  opacity: 75%;
+}
+
+#phone-number {
+  position: relative;
+  margin: 0px 0 10px 30px;
+  bottom: 2px;
+  border-radius: 3px;
+  border-color: rgb(201, 200, 200);
+  border-style: solid;
+  height: 30px;
+  width: 250px;
 }
 
 .filter {

--- a/style.css
+++ b/style.css
@@ -947,6 +947,11 @@ h2 {
   width: 250px;
 }
 
+.booking_button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .filter {
   /* Made the filter window only visible in desktop mode, for now */
   display: none;


### PR DESCRIPTION
This pull request implements a phone number validation feature that ensures users can only enter a valid Swedish phone number in the format ( +46 ) <PhoneNumber>. Users can also leave the phone number field blank.

Phone Number Format: The field allows the user to type a Swedish phone number in the format ( +46 ) <PhoneNumber>, with the area code +46 being prefilled when the user focuses on the input.
Validation Logic:
If the user inputs a phone number with exactly 10 digits after the country code (e.g., ( +46 ) 1234567890), it is accepted as a valid phone number.
The system checks if the phone number starts with the Swedish country code ( +46 ), and only allows valid numbers (length 10 after the country code).
If the number is invalid or the format is wrong, the system hides the modal containing the form.
If the phone number is not provided, the modal remains visible.
Changes Made:

Added event listener to auto-fill the Swedish country code (+46) when the user focuses on the phone number input.
Introduced validation logic for the phone number format (length of 15 for (+46) + 10 digits).
Added logic to hide or display modal based on whether the phone number is valid or not.

Testing:

Focus on the phone number input field and check that it automatically pre-fills with ( +46 ).
Enter a valid Swedish phone number in the format ( +46 ) 1234567890 and verify that it passes validation.
Enter an invalid phone number or incorrect format and verify that the modal is hidden.
Leave the phone number field blank and verify that the modal remains visible.

Fixed the code based on the feedback from the old pull request "Add Phone Input Field and Validation for Optional Submission #33" 
closed due to a typing mistake while mergin the latest main to branch, and instead created an new branch.

This fix and rework of code was done with help from @viktornoskire.

