### PR TITLE
Larger screen challenges

### DIFF
--- a/src/sections/challenges.scss
+++ b/src/sections/challenges.scss
@@ -472,6 +472,11 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 1.4rem;
+    justify-content: center;
+
+    @include breakpoint($ultra-large-screen-breakpoint) {
+    grid-template-columns: repeat(4, 1fr);
+    }
   }
 
   .challenges__room {

--- a/src/sections/lib.scss
+++ b/src/sections/lib.scss
@@ -12,6 +12,7 @@ $black: black;
 /*Screen size variables*/
 $large-screen-breakpoint: 1280px;
 $max-screen-breakpoint: 1500px;
+$ultra-large-screen-breakpoint: 1950px;
 /*Project button mixins*/
 @mixin blueButton {
   background-color: $lightblue;

--- a/src/style.scss
+++ b/src/style.scss
@@ -22,4 +22,8 @@ body {
   max-width: $max-screen-breakpoint;
   margin: auto;
   background-color: $white;
+
+  @include breakpoint($ultra-large-screen-breakpoint) {
+    min-width: 1800px;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -1227,6 +1227,12 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 1.4rem;
+  justify-content: center;
+}
+@media screen and (min-width: 1950px) {
+  .challenges #challenges__container {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 .challenges .challenges__room {
   box-shadow: 0px 0px 10px 0px #b6bdb5;
@@ -1414,6 +1420,11 @@ body {
   max-width: 1500px;
   margin: auto;
   background-color: white;
+}
+@media screen and (min-width: 1950px) {
+  body {
+    min-width: 1800px;
+  }
 }
 
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
# Very simple and quick user experience upgrade
Small upgrade for users with larger screens.

## Changed: 
What I've changed in this Pull  Request is when the user has a larger or equal screen width to 1950 pixels, on the challenges page, there are four challenges per row instead of three per row as it is at 1500 pixel width.

Also the max-width changes from 1500 pixels to 1800 pixels, so the main page isn't so small for large screen users. 

### At 1500 pixel width:
![1500](https://github.com/user-attachments/assets/36135198-c039-4761-a085-afa550ad93b0)

### At 1950 pixel width:
![1950](https://github.com/user-attachments/assets/0dee82f2-785b-46da-bff6-4c235f39e845)